### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/ety/data.py
+++ b/ety/data.py
@@ -23,15 +23,16 @@ def parse_row(data_row):
 def load_relety():
     global etyms
     etyms = []
-    with io.open(resource_filename(
-            'ety', 'wn/etymwn-relety.json'), 'r') as f:
+    resource = resource_filename('ety', 'wn/etymwn-relety.json')
+    with io.open(resource, 'r', encoding='utf-8') as f:
         etyms = json.load(f)
 
 
 def load_country_codes():
     global langs
     langs = []
-    with io.open(resource_filename('ety', 'wn/iso-639-3.json'), 'r') as f:
+    resource = resource_filename('ety', 'wn/iso-639-3.json')
+    with io.open(resource, 'r', encoding='utf-8') as f:
         countries_json = json.load(f)
     for country in countries_json:
         langs.append({


### PR DESCRIPTION
hello 👋 

I'm currently getting the following error on my Windows machine:

```python
>>> import ety
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Alex\repos\ety-python\ety\__init__.py", line 10, in <module>
    data.load()
  File "C:\Users\Alex\repos\ety-python\ety\data.py", line 45, in load
    load_country_codes()
  File "C:\Users\Alex\repos\ety-python\ety\data.py", line 35, in load_country_codes
    countries_json = json.load(f)
  File "C:\Python36\Lib\json\__init__.py", line 296, in load
    return loads(fp.read(),
  File "C:\Users\Alex\.virtualenvs\ety-python-_lx5rZzb\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 8732: character maps to <undefined>
```

This PR should fix this by specifying the encoding.