### PR TITLE
Remove globals

### DIFF
--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -6,9 +6,6 @@ from treelib import Tree
 
 from . import data
 
-# Load etymology data
-data.load()
-
 
 def cli():
     parser = argparse.ArgumentParser()

--- a/ety/data.py
+++ b/ety/data.py
@@ -6,17 +6,6 @@ import json
 from pkg_resources import resource_filename
 
 
-def parse_row(data_row):
-    a_lang, a_word = data_row[0].split(': ')
-    b_lang, b_word = data_row[2].split(': ')
-    return {
-        'a_lang': a_lang,
-        'a_word': a_word,
-        'b_lang': b_lang,
-        'b_word': b_word,
-    }
-
-
 def load_relety():
     resource = resource_filename('ety', 'wn/etymwn-relety.json')
     with io.open(resource, 'r', encoding='utf-8') as f:

--- a/ety/data.py
+++ b/ety/data.py
@@ -5,9 +5,6 @@ import json
 
 from pkg_resources import resource_filename
 
-etyms = []
-langs = []
-
 
 def parse_row(data_row):
     a_lang, a_word = data_row[0].split(': ')
@@ -21,15 +18,13 @@ def parse_row(data_row):
 
 
 def load_relety():
-    global etyms
-    etyms = []
     resource = resource_filename('ety', 'wn/etymwn-relety.json')
     with io.open(resource, 'r', encoding='utf-8') as f:
         etyms = json.load(f)
+    return etyms
 
 
 def load_country_codes():
-    global langs
     langs = []
     resource = resource_filename('ety', 'wn/iso-639-3.json')
     with io.open(resource, 'r', encoding='utf-8') as f:
@@ -39,8 +34,8 @@ def load_country_codes():
             'name': country['name'],
             'iso6393': country['iso6393'],
         })
+    return langs
 
 
-def load():
-    load_relety()
-    load_country_codes()
+etyms = load_relety()
+langs = load_country_codes()


### PR DESCRIPTION
hello :wave: !

This removes the globals in `data.py`. Because the `.load()` call is made right after `data` is imported, it seems like that call could be removed.

I also removed `parse_row` as it was unreferenced. I'm assuming it was from when the data was a tsv? 