### PR TITLE
Allow running as a module

### DIFF
--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -11,7 +11,7 @@ data.load()
 
 
 def cli():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog="ety")
     parser.add_argument("words", type=str, nargs='+',
                         help="the search word(s)")
     parser.add_argument("-r", "--recursive", help="search origins recursively",

--- a/ety/__main__.py
+++ b/ety/__main__.py
@@ -1,0 +1,3 @@
+import ety
+
+ety.cli()


### PR DESCRIPTION
This adds the ability to do `python -m ety` on the ety folder so installing isn't required to run on the command line.

I added the `prog` keyword argument to ArgumentParser to change the output from `usage: __main__.py [-h] [-r] [-t] words [words ...]` to `usage: ety [-h] [-r] [-t] words [words ...]` for this use case.