### PR TITLE
Encapsulate Word

### DIFF
--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -40,17 +40,16 @@ def cli():
 
 
 class Word(object):
-    def __init__(self, word, language):
+    def __init__(self, word, language='eng'):
         self.word = word
         self.lang_code = language
         self.lang_name = lang_name(language)
-        self.pretty = prettify_word(word, language)
 
-
-def prettify_word(word, language):
-    if language:
-        return "%s (%s)" % (word, lang_name(language))
-    return word
+    @property
+    def pretty(self):
+        return "{word} ({lang})".format(
+            word=self.word,
+            lang=self.lang_name)
 
 
 def lang_name(code):

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -130,5 +130,5 @@ def tree(word, word_lang='eng'):
 
 def random_word(lang='eng'):
     row = list(filter(lambda entry: entry['a_lang'] == lang, data.etyms))
-    word = choice(row)['a_word']
+    word = Word(choice(row)['a_word'], lang)
     return word

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -81,7 +81,7 @@ def origins(word, word_lang='eng', recursive=False):
         result.append(origin)
 
         if recursive:
-            for child in origins(origin.word, origin.lang_code):
+            for child in origins(origin.word, origin.lang_code, True):
                 if origin.word != child.word:
                     result.append(child)
     return result

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -57,8 +57,10 @@ class Word(object):
     def origins(self):
         if not self._origins:
             row = list(filter(
-                lambda entry: entry['a_word'] == self.word and entry[
-                    'a_lang'] == self.lang_code, data.etyms))
+                lambda entry: (
+                    entry['a_word'].lower() == self.word.lower() and
+                    entry['a_lang'].lower() == self.lang_code.lower()),
+                data.etyms))
 
             self._origins = [
                 Word(item['b_word'], item['b_lang'])

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -74,7 +74,7 @@ class Word(object):
             root_key = uuid4()
 
             # Create parent node
-            ety_tree.create_node(self.pretty, root_key)
+            ety_tree.create_node(self, root_key)
 
             def _tree(tree_obj, word, parent, parent_word):
                 word_origins = origins(word.word, word_lang=word.lang_code)
@@ -83,7 +83,7 @@ class Word(object):
                     # Recursive call to add child origins
                     if parent_word == origin.word:
                         continue
-                    tree_obj.create_node(origin.pretty, key, parent=parent)
+                    tree_obj.create_node(origin, key, parent=parent)
                     _tree(tree_obj, origin, key, origin.word)
             # Add child etymologies
             _tree(ety_tree, self, root_key, self.word)
@@ -97,6 +97,14 @@ class Word(object):
             if lang['iso6393'] == code:
                 return lang['name']
         return "Unknown language"
+
+    def __lt__(self, other):
+        if isinstance(other, Word):
+            return self.pretty < other.pretty
+        return self.pretty < other
+
+    def __str__(self):
+        return self.pretty
 
 
 def origins(word, word_lang='eng', recursive=False):

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -62,7 +62,7 @@ class Word(object):
 
             self._origins = [
                 Word(item['b_word'], item['b_lang'])
-                for item in row]
+                for item in row if item['b_word'] != self.word]
 
         return self._origins
 
@@ -115,7 +115,7 @@ class Word(object):
 def origins(word, word_lang='eng', recursive=False):
     source_word = Word(word, word_lang)
 
-    result = []
+    result = [source_word]
 
     for origin in source_word.origins:
         result.append(origin)

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -106,6 +106,11 @@ class Word(object):
     def __str__(self):
         return self.pretty
 
+    def __repr__(self):
+        return 'Word({word}, language={lang})'.format(
+            word=self.word, lang=self.lang_code
+        )
+
 
 def origins(word, word_lang='eng', recursive=False):
     source_word = Word(word, word_lang)

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -43,7 +43,7 @@ class Word(object):
     def __init__(self, word, language='eng'):
         self.word = word
         self.lang_code = language
-        self.lang_name = lang_name(language)
+        self.lang_name = self._find_lang_name(language)
 
     @property
     def pretty(self):
@@ -51,12 +51,11 @@ class Word(object):
             word=self.word,
             lang=self.lang_name)
 
-
-def lang_name(code):
-    for lang in data.langs:
-        if lang['iso6393'] == code:
-            return lang['name']
-    return "Unknown language"
+    def _find_lang_name(self, code):
+        for lang in data.langs:
+            if lang['iso6393'] == code:
+                return lang['name']
+        return "Unknown language"
 
 
 def origins(word, word_lang='eng', recursive=False):

--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -115,7 +115,7 @@ class Word(object):
 def origins(word, word_lang='eng', recursive=False):
     source_word = Word(word, word_lang)
 
-    result = [source_word]
+    result = []
 
     for origin in source_word.origins:
         result.append(origin)


### PR DESCRIPTION
hello! :wave: 

The diff here is bigger than I thought. The main change here is I've moved the concept of `origins` and `tree` under the `Word` class. The underlying code hasn't changed much.

The `origins` and `tree` functions left in the package namespace act as wrappers to the `Word` class.

Hopefully, the commit's give a better idea of what's changed (versus the PR diff) as I tried to keep them in logical chunks. 

I snuck in a fix for #8 at the end.

There is one failing test, but that's due to a function moving.

### Examples

```python
>>> import ety

>>> ety.origins("potato")
[Word(batata, language=tnq)]

>>> ety.origins("drink", recursive=True)
[Word(drync, language=ang), Word(drinken, language=enm), Word(drincan, language=ang)]

>>> word = ety.Word("cheese")
>>> word.lang_code
'eng'
>>> word.lang_name
'English'
>>> word.pretty
'cheese (English)'
>>> print(word)
cheese (English)
>>> word.origins
[Word(chese, language=enm)]

>>> ety.tree("aerodynamically")
<treelib.tree.Tree object at 0x7fc1b1cf2f60>

>>> print(ety.tree("aerodynamically"))
aerodynamically (English)
├── -ally (English)
└── aerodynamic (English)
    ├── aero- (English)
    │   └── ἀήρ (Ancient Greek (to 1453))
    └── dynamic (English)
        └── dynamique (French)
            └── δυναμικός (Ancient Greek (to 1453))
                └── δύναμις (Ancient Greek (to 1453))
                    └── δύναμαι (Ancient Greek (to 1453))
```