### PR TITLE
Refactor cli()

### DIFF
--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -15,24 +15,19 @@ def cli():
                         action="store_true")
     args = parser.parse_args()
 
-    if args.tree:
-        for word in args.words:
-            word_origins = origins(word, recursive=args.recursive)
-            if not word_origins:
-                print("No origins found for word: '%s'" % word)
-                continue
-            print(tree(word))
-        return 0
-
     for word in args.words:
         word_origins = origins(word, recursive=args.recursive)
+
         if not word_origins:
             print("No origins found for word: '%s'" % word)
+            continue
 
-        lines = []
-        for origin in word_origins:
-            lines.append(str(origin))
-        print('\n'.join(lines))
+        if args.tree:
+            result = tree(word)
+        else:
+            result = '\n'.join(origin.pretty for origin in word_origins)
+
+        print(result)
 
     return 0
 


### PR DESCRIPTION
This is tidy up of the `cli()` function, mainly to remove duplication.

For each output, I've assigned what is about to be put to the console to `result`. This is to make #25 easier to implement (if it's needed), as separators only need to be implemented in one place.