### PR TITLE
Use tree object

### DIFF
--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -23,7 +23,7 @@ def cli():
             continue
 
         if args.tree:
-            result = tree(word)
+            result = str(tree(word)).strip()
         else:
             result = '\n'.join(origin.pretty for origin in word_origins)
 

--- a/ety/word.py
+++ b/ety/word.py
@@ -42,7 +42,7 @@ class Word(object):
         root_key = uuid4()
 
         # Create parent node
-        ety_tree.create_node(root, root_key)
+        ety_tree.create_node(root, root_key, data=self)
 
         # Add child etymologies
         self._tree(ety_tree, root_key)
@@ -59,7 +59,7 @@ class Word(object):
             if self.word == origin.word:
                 continue
 
-            tree_obj.create_node(origin.pretty, key, parent=parent)
+            tree_obj.create_node(origin.pretty, key, parent=parent, data=origin)
             origin._tree(tree_obj, key)
 
     @property

--- a/ety/word.py
+++ b/ety/word.py
@@ -59,7 +59,8 @@ class Word(object):
             if self.word == origin.word:
                 continue
 
-            tree_obj.create_node(origin.pretty, key, parent=parent, data=origin)
+            tree_obj.create_node(
+                origin.pretty, key, parent=parent, data=origin)
             origin._tree(tree_obj, key)
 
     @property

--- a/ety/word.py
+++ b/ety/word.py
@@ -47,7 +47,7 @@ class Word(object):
         # Add child etymologies
         self._tree(ety_tree, root_key)
 
-        return str(ety_tree).strip()
+        return ety_tree
 
     def _tree(self, tree_obj, parent):
         source_word = Word(self.word, self.language.iso)


### PR DESCRIPTION
This changes `Word.tree()` so it returns the `treelib.Tree` object.

I also added using the `data` keyword argument for `create_node` as mentioned here: http://treelib.readthedocs.io/en/latest/examples.html#advanced-usage

```python
>>> aero_tree = ety.tree("aerodynamically")
>>> aero_tree
<treelib.tree.Tree object at 0x7f5cd5c9dfd0>
>>> print(aero_tree)
aerodynamically (English)
├── -ally (English)
└── aerodynamic (English)
    ├── aero- (English)
    │   └── ἀήρ (Ancient Greek (to 1453))
    └── dynamic (English)
        └── dynamique (French)
            └── δυναμικός (Ancient Greek (to 1453))
                └── δύναμις (Ancient Greek (to 1453))
                    └── δύναμαι (Ancient Greek (to 1453))

>>> aero_tree.show(data_property="language")
English
├── English
└── English
    ├── English
    │   └── Ancient Greek (to 1453)
    └── English
        └── French
            └── Ancient Greek (to 1453)
                └── Ancient Greek (to 1453)
                    └── Ancient Greek (to 1453)

>>> aero_tree.show(data_property="word")
aerodynamically
├── -ally
└── aerodynamic
    ├── aero-
    │   └── ἀήρ
    └── dynamic
        └── dynamique
            └── δυναμικός
                └── δύναμις
                    └── δύναμαι
```