### PR TITLE
Fix circular reference

### DIFF
--- a/ety/word.py
+++ b/ety/word.py
@@ -22,13 +22,12 @@ class Word(object):
             lambda entry: entry['a_word'] == self.word and entry[
                 'a_lang'] == self.language.iso, etymwn_data))
 
-        result = []
-        for item in row:
-            result.append(Word(item['b_word'], item['b_lang']))
+        result = [Word(item['b_word'], item['b_lang']) for item in row]
+
         if recursive:
             for origin in result:
                 for child in origin.origins():
-                    if origin.word != child.word:
+                    if origin.word != child.word and child not in result:
                         result.append(child)
 
         self._origins = result
@@ -73,6 +72,11 @@ class Word(object):
         if isinstance(other, Word):
             return self.pretty < other.pretty
         return self.pretty < other
+
+    def __eq__(self, other):
+        if isinstance(other, Word):
+            return self.pretty == other.pretty
+        return self.pretty == other
 
     def __str__(self):
         return self.pretty

--- a/ety/word.py
+++ b/ety/word.py
@@ -11,7 +11,7 @@ class Word(object):
         self.word = word
         self.language = Language(language)
         self._origins = None
-        self._tree_key = self.word + self.language.iso
+        self._id = u"{}:{}".format(self.word, self.language.iso)
 
     def origins(self, recursive=False):
         if self._origins:
@@ -37,7 +37,7 @@ class Word(object):
 
         word_obj = Word(self.word, self.language.iso)
         root = word_obj.pretty
-        root_key = self._tree_key
+        root_key = self._id
 
         # Create parent node
         ety_tree.create_node(root, root_key, data=self)
@@ -52,7 +52,7 @@ class Word(object):
         word_origins = source_word.origins()
 
         for origin in word_origins:
-            key = origin._tree_key
+            key = origin._id
             # Recursive call to add child origins
             if self.word == origin.word:
                 continue
@@ -78,7 +78,7 @@ class Word(object):
 
     def __eq__(self, other):
         if isinstance(other, Word):
-            return self.pretty == other.pretty
+            return self._id == other._id
         return self.pretty == other
 
     def __str__(self):

--- a/ety/word.py
+++ b/ety/word.py
@@ -26,7 +26,9 @@ class Word(object):
         if recursive:
             for origin in result:
                 for child in origin.origins():
-                    if origin.word != child.word and child not in result:
+                    no_duplicates = child not in result and child != self
+
+                    if origin.word != child.word and no_duplicates:
                         result.append(child)
 
         self._origins = result

--- a/ety/word.py
+++ b/ety/word.py
@@ -26,10 +26,15 @@ class Word(object):
         if recursive:
             for origin in result:
                 for child in origin.origins():
-                    no_duplicates = child not in result and child != self
+                    duplicates = (
+                        origin.word == child.word and
+                        child in result and
+                        child == self
+                    )
 
-                    if origin.word != child.word and no_duplicates:
-                        result.append(child)
+                    if duplicates:
+                        continue
+                    result.append(child)
 
         self._origins = result
         return self._origins

--- a/ety/word.py
+++ b/ety/word.py
@@ -27,9 +27,9 @@ class Word(object):
             for origin in result:
                 for child in origin.origins():
                     duplicates = (
-                        origin.word == child.word and
-                        child in result and
-                        child == self
+                        origin.word == child.word
+                        and child in result  # noqa: W503
+                        and child == self  # noqa: W503
                     )
 
                     if duplicates:


### PR DESCRIPTION
This fixes #20.

- Dropped `uuid` in favour of each word having its own id. I think this is logical as it allows `origins()` and `tree()` to ignore a word if it's already in the result. E.g.
```shell
$ python -m ety -t software
software (English)
├── -ware (English)
│   └── software (English)   # <- I think this doesn't make sense
└── soft (English)
    └── softe (Middle English (1100-1500))
```

- Added a couple more checks around when we should add a word to the `origins()` results. Again this drops out duplicated words. E.g.
```shell
$ python -m ety -r software
-ware (English)
soft (English)
software (English)   # <- Again, I think this doesn't make sense
softe (Middle English (1100-1500))
```

- Added an Exception case when trying to add a child node to a Tree, as it's possible the key might already exist now (circular references).

- Added `__eq__` for checking if 2 `Word`s are the same.

