### PR TITLE
Extract tree into an EtyTree

### DIFF
--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -1,8 +1,11 @@
+from __future__ import print_function
+
 import argparse
 from random import choice
 
 from . import data
 from .word import Word, Language  # noqa: F401
+from .tree import EtyTree
 
 
 def cli():
@@ -23,15 +26,12 @@ def cli():
             continue
 
         if args.tree:
-            result = str(tree(word)).strip()
+            result = tree(word)
         else:
-            result = '\n'
-            if word is args.words[0]:
-                result = ''
-            result += '\033[1m' + word + '\033[0m \n \u2022 '
+            result = '\033[1m' + word + '\033[0m \n \u2022 '
             result += '\n \u2022 '.join(root.pretty for root in roots)
 
-        print(result)
+        print(result, end="\n\n")
 
     return 0
 
@@ -49,7 +49,7 @@ def origins(word, word_lang='eng', recursive=False):
 
 def tree(word, word_lang='eng'):
     source_word = _get_source_word(word, word_lang)
-    return source_word.tree()
+    return EtyTree(source_word)
 
 
 def random_word(lang='eng'):

--- a/ety/tree.py
+++ b/ety/tree.py
@@ -6,8 +6,8 @@ import ety
 class EtyTree(treelib.Tree):
 
     def __init__(self, word=''):
-        if isinstance(word, ("".__class__, u"".__class__)):
-            word = ety.Word(word)
+        if not isinstance(word, ety.Word):
+            raise ValueError("word must be an instance of 'ety.Word'")
         self.source_word = word
 
         super(EtyTree, self).__init__()

--- a/ety/tree.py
+++ b/ety/tree.py
@@ -1,0 +1,45 @@
+
+import treelib
+import ety
+
+
+class EtyTree(treelib.Tree):
+
+    def __init__(self, word=''):
+        if isinstance(word, ("".__class__, u"".__class__)):
+            word = ety.Word(word)
+        self.source_word = word
+
+        super(EtyTree, self).__init__()
+
+        if not self.source_word.origins():
+            return
+
+        self.create_node(word.pretty, word._id, data=word)
+
+        self.add_children(self.source_word)
+
+    def add_children(self, parent):
+        for origin in parent.origins():
+            key = origin._id
+
+            try:
+                self.create_node(
+                    origin.pretty, key, parent=parent._id, data=origin
+                )
+            except treelib.exceptions.DuplicatedNodeIdError:
+                continue
+
+            self.add_children(origin)
+
+    def __bool__(self):
+        return bool(self.source_word.origins())
+
+    def __str__(self):
+        try:
+            return super(EtyTree, self).__str__().strip()
+        except treelib.exceptions.NodeIDAbsentError:
+            return ""
+
+    def __repr__(self):
+        return u"EtyTree(word='{}')".format(self.source_word.word)

--- a/ety/word.py
+++ b/ety/word.py
@@ -1,7 +1,6 @@
-import treelib
-
 from .data import etyms as etymwn_data
 from .language import Language
+from .tree import EtyTree
 
 
 class Word(object):
@@ -34,37 +33,7 @@ class Word(object):
         return self._origins
 
     def tree(self):
-        ety_tree = treelib.Tree()
-
-        word_obj = Word(self.word, self.language.iso)
-        root = word_obj.pretty
-        root_key = self._id
-
-        # Create parent node
-        ety_tree.create_node(root, root_key, data=self)
-
-        # Add child etymologies
-        self._tree(ety_tree, root_key)
-
-        return ety_tree
-
-    def _tree(self, tree_obj, parent):
-        source_word = Word(self.word, self.language.iso)
-        word_origins = source_word.origins()
-
-        for origin in word_origins:
-            key = origin._id
-            # Recursive call to add child origins
-            if self.word == origin.word:
-                continue
-
-            try:
-                tree_obj.create_node(
-                    origin.pretty, key, parent=parent, data=origin
-                )
-            except treelib.exceptions.DuplicatedNodeIdError:
-                continue
-            origin._tree(tree_obj, key)
+        return EtyTree(self)
 
     @property
     def pretty(self):


### PR DESCRIPTION
This extracts the tree logic out of `Word` and into its own class. I've based the class off `treelib.Tree` so it functions like a `Tree` object, but with the added bonus that we can control the `__repr__`.

It's also now valid to have an empty tree, so maybe closes #13?

```python
>>> ety.tree("flower")
EtyTree(word='flower')

>>> print(ety.tree("flower"))
flower (English)
└── flour (Middle English (1100-1500))
    └── flur (Anglo-Norman)
        ├── flor (Latin)
        └── flor (Old French (842-ca. 1400))
            ├── florem (Latin)
            └── flos (Latin)

>>> ety.EtyTree("green")
EtyTree(word='green')

>>> print(ety.EtyTree("green"))
green (English)
└── grene (Middle English (1100-1500))
    └── grene (Old English (ca. 450-1100))

>>> ety.tree("dwiovwh")
EtyTree(word='dwiovwh')

>>> print(ety.tree("dwiovwh"))


```