### PR TITLE
Highlight word if it's the source word

### DIFF
--- a/ety/__init__.py
+++ b/ety/__init__.py
@@ -6,8 +6,6 @@ from __future__ import print_function
 import argparse
 from random import choice
 
-import colorful
-
 from . import data
 from .tree import EtyTree
 from .word import Word, Language  # noqa: F401
@@ -25,6 +23,7 @@ def cli():
 
     output = ''
     for word in args.words:
+        source_word = Word(word, is_source=True)
         roots = origins(word, recursive=args.recursive)
 
         if not roots:
@@ -32,9 +31,9 @@ def cli():
             continue
 
         if args.tree:
-            output += '%s\n\n' % str(tree(word))
+            output += '%s\n\n' % str(tree(source_word))
         else:
-            output += '\n\n%s\n \u2022 ' % colorful.bold(word)
+            output += '\n\n%s\n \u2022 ' % source_word
             output += '\n \u2022 '.join(root.pretty for root in roots)
 
     print(output.strip())
@@ -45,7 +44,7 @@ def cli():
 def _get_source_word(word, word_lang):
     if isinstance(word, Word):
         return word
-    return Word(word, word_lang)
+    return Word(word, word_lang, is_source=True)
 
 
 def origins(word, word_lang='eng', recursive=False):

--- a/ety/word.py
+++ b/ety/word.py
@@ -1,17 +1,20 @@
 #!/usr/local/bin/python
 # -*- coding: utf-8 -*-
 
+import colorful
+
 from .data import etyms as etymwn_data
 from .language import Language
 from .tree import EtyTree
 
 
 class Word(object):
-    def __init__(self, word, language='eng'):
+    def __init__(self, word, language='eng', is_source=False):
         if not isinstance(word, ("".__class__, u"".__class__)):
             raise ValueError('word must be a string')
         self.word = word
         self.language = Language(language)
+        self.is_source = is_source
         self._origins = None
         self._id = u"{}:{}".format(self.word, self.language.iso)
 
@@ -40,8 +43,9 @@ class Word(object):
 
     @property
     def pretty(self):
+        word = colorful.bold(self.word) if self.is_source else self.word
         return u"{word} ({lang})".format(
-            word=self.word,
+            word=word,
             lang=self.language.name)
 
     def __lt__(self, other):


### PR DESCRIPTION
This moves the new `colorful.bold` highlighting to a word's `pretty` property. A `Word` now has the `is_source` attribute to determine if it's the source. If it is, it gets highlighted.

I think this will be helpful if we ever add a reverse origins/tree. You can set a word as the source word and ensure it gets highlighted wherever it ends up in a tree.