### PR TITLE
Add CLI tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import sys
 import ety
 
 
@@ -9,6 +10,44 @@ def test_circular_etymology():
     """Test to avoid https://github.com/jmsv/ety-python/issues/20
     This method is run with a 10 second timeout (see Makefile test)"""
     ety.origins('software', recursive=True)
+
+
+def stdout_capture(func):
+    """Decorator to capture stdout during a test for testing the command line
+    If you need to actually print to stdout during a test, use ._print
+    """
+    sys_stdout_write = sys.stdout.write
+
+    class MockWriter(object):
+        _print = sys_stdout_write
+
+        def __init__(self):
+            self._value = u""
+
+        def __call__(self, message):
+            self._value += message
+
+        @property
+        def value(self):
+            # Remove trailing new line so tests make more sense
+            return self._value.strip()
+
+        @property
+        def lines(self):
+            return len(self.value.split("\n"))
+
+    def wrapper(obj):
+        output = MockWriter()
+        # Override stdout.write with the mock
+        sys.stdout.write = output
+
+        # Pass the mock to the test
+        result = func(obj, output)
+
+        # Restore stdout
+        sys.stdout.write = sys_stdout_write
+        return result
+    return wrapper
 
 
 class TestEty(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -74,6 +74,89 @@ class TestEty(unittest.TestCase):
         self.assertGreaterEqual(len(str(
             ety.tree('fabric')).split('\n')), 4)
 
+    @stdout_capture
+    def test_cli_no_args(self, output):
+        words = ["test"]
+        sys.argv = ["ety.py", "test"]
+
+        ety.cli()
+
+        origins = ety.origins("test")
+
+        expected_lines = len(words) + len(origins)
+
+        self.assertEqual(expected_lines, output.lines)
+
+    @stdout_capture
+    def test_cli_recursive(self, output):
+        words = ["test"]
+        sys.argv = ["ety.py", "-r"] + words
+
+        ety.cli()
+
+        origins = ety.origins("test", recursive=True)
+
+        expected_lines = len(words) + len(origins)
+
+        self.assertEqual(expected_lines, output.lines)
+
+    @stdout_capture
+    def test_cli_tree(self, output):
+        words = ["test"]
+        sys.argv = ["ety.py", "-t"] + words
+
+        ety.cli()
+
+        tree = ety.tree("test")
+        expected_lines = len(tree)
+
+        self.assertEqual(expected_lines, output.lines)
+
+    @stdout_capture
+    def test_cli_multiple_words(self, output):
+        words = ["test", "word"]
+        sys.argv = ["ety.py"] + words
+
+        ety.cli()
+
+        origins = [
+            origin for word in words
+            for origin in ety.origins(word)
+        ]
+
+        expected_lines = len(words) + len(origins) + len(words) - 1
+
+        self.assertEqual(expected_lines, output.lines)
+
+    @stdout_capture
+    def test_cli_multiple_words_recursive(self, output):
+        words = ["test", "word"]
+        sys.argv = ["ety.py", "-r"] + words
+
+        ety.cli()
+
+        origins = [
+            origin for word in words
+            for origin in ety.origins(word, recursive=True)
+        ]
+
+        expected_lines = len(words) + len(origins) + len(words) - 1
+
+        self.assertEqual(expected_lines, output.lines)
+
+    @stdout_capture
+    def test_cli_multiple_words_tree(self, output):
+        words = ["test", "word"]
+        sys.argv = ["ety.py", "-t"] + words
+
+        ety.cli()
+
+        trees = [ety.tree(word) for word in words]
+
+        expected_length = sum(len(tree) for tree in trees) + len(words) - 1
+
+        self.assertEqual(expected_length, output.lines)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -25,7 +25,10 @@ def stdout_capture(func):
             self._value = u""
 
         def write(self, message):
-            self._value += message
+            try:
+                self._value += message.decode("utf-8")
+            except AttributeError:  # Already decoded
+                self._value += message
 
         @property
         def value(self):

--- a/tests.py
+++ b/tests.py
@@ -16,15 +16,15 @@ def stdout_capture(func):
     """Decorator to capture stdout during a test for testing the command line
     If you need to actually print to stdout during a test, use ._print
     """
-    sys_stdout_write = sys.stdout.write
+    sys_stdout = sys.stdout
 
     class MockWriter(object):
-        _print = sys_stdout_write
+        _print = sys_stdout.write
 
         def __init__(self):
             self._value = u""
 
-        def __call__(self, message):
+        def write(self, message):
             self._value += message
 
         @property
@@ -39,13 +39,13 @@ def stdout_capture(func):
     def wrapper(obj):
         output = MockWriter()
         # Override stdout.write with the mock
-        sys.stdout.write = output
+        sys.stdout = output
 
         # Pass the mock to the test
         result = func(obj, output)
 
         # Restore stdout
-        sys.stdout.write = sys_stdout_write
+        sys.stdout = sys_stdout
         return result
     return wrapper
 


### PR DESCRIPTION
This adds some tests around the CLI. 

I've written a decorator to wrap the CLI tests so we don't need to change anything about `ety.cli()` to gain access to the output.
