### PR TITLE
Update to Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,14 @@
 language: python
-dist: xenial
 
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
   - "nightly"
 
 matrix:
-  include:
-    - python: "3.4"
-      dist: trusty
-  exclude:
-    - python: "3.4"
-      dist: xenial
   allow_failures:
     - python: "nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "nightly"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
     - python: 3.7
       dist: xenial
+      sudo: true
 
     - python: nightly
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
   - "nightly"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,25 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "nightly"
-
 matrix:
+  include:
+    - python: 2.7
+      dist: trusty
+
+    - python: 3.4
+      dist: trusty
+
+    - python: 3.5
+      dist: trusty
+
+    - python: 3.6
+      dist: trusty
+
+    - python: 3.7
+      dist: xenial
+
+    - python: nightly
+      dist: xenial
+
   allow_failures:
     - python: "nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+dist: xenial
+sudo: true
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 dist: xenial
-sudo: true
 
 python:
   - "2.7"
@@ -11,6 +10,12 @@ python:
   - "nightly"
 
 matrix:
+  include:
+    - python: "3.4"
+      dist: trusty
+  exclude:
+    - python: "3.4"
+      dist: xenial
   allow_failures:
     - python: "nightly"
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
     keywords='etymology origins english language words',


### PR DESCRIPTION
Python 3.7 was released yesterday/today 🎉 🎉 

This adds 3.7 to the Travis file and the setup file.

Tests are running fine, except we are now getting `FutureWarning`'s from `pycodestyle` as part of [PEP 565](https://www.python.org/dev/peps/pep-0565/) (Improved DeprecationWarning handling).

I am curious to see if the Travis build for 3.7 fails, as nightly was previously failing to build.